### PR TITLE
Adding string identifier for analysis date

### DIFF
--- a/lang/en/plagiarism_compilatio.php
+++ b/lang/en/plagiarism_compilatio.php
@@ -73,6 +73,7 @@ $string['analysistype_help'] = '<p>There are 3 possible options:</p>
 $string['analysistypeauto'] = 'Instant';
 $string['analysistypemanual'] = 'Manual';
 $string['analysistypeprog'] = 'Timed';
+$string['analysisdate'] = 'Analysis Date';
 $string['enabledandworking'] = 'The Compilatio plugin is enabled and working.';
 $string['usedcredits'] = '<strong>You have used {$a->used} credit(s) of {$a->credits} and have {$a->remaining} credit(s) remaining</strong>';
 $string['startanalysis'] = 'Start analysis';

--- a/lib.php
+++ b/lib.php
@@ -652,7 +652,7 @@ function compilatio_get_form_elements($mform, $defaults=false) {
     $mform->setDefault('compilatio_analysistype', COMPILATIO_ANALYSISTYPE_AUTO);
 
     if (!$defaults) { // Only show this inside a module page - not on default settings pages.
-        $mform->addElement('date_time_selector', 'compilatio_timeanalyse', get_string('analysisdate', 'compilatioassignment'),
+        $mform->addElement('date_time_selector', 'compilatio_timeanalyse', get_string('analysisdate', 'plagiarism_compilatio'),
             array('optional'=>false));
         $mform->setDefault('compilatio_timeanalyse', time()+7*24*3600);
         $mform->disabledif('compilatio_timeanalyse', 'compilatio_analysistype', 'noteq', COMPILATIO_ANALYSISTYPE_PROG);


### PR DESCRIPTION
Hi Dan,
I was getting error - Invalid get_string() identifier: 'analysisdate' or component 'compilatioassignment'. Perhaps you are missing $string['analysisdate'] = ''; in mod/compilatioassignment/lang/en/compilatioassignment.php?

Here is patch for this.
Kanika
