### PR TITLE
Removed duplicate SQL line

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -515,7 +515,7 @@ class plagiarism_plugin_compilatio extends plagiarism_plugin {
     }
 
     /**
-     * called by admin/cron.php 
+     * called by admin/cron.php
      *
      */
     public function cron() {
@@ -529,7 +529,6 @@ class plagiarism_plugin_compilatio extends plagiarism_plugin {
         $sql = "SELECT cf.* FROM {plagiarism_compilatio_files} cf
                 LEFT JOIN {plagiarism_compilatio_config} cc1 ON cc1.cm = cf.cm
                 LEFT JOIN {plagiarism_compilatio_config} cc2 ON cc2.cm = cf.cm
-                LEFT JOIN {plagiarism_compilatio_config} cc3 ON cc3.cm = cf.cm
                 LEFT JOIN {plagiarism_compilatio_config} cc3 ON cc3.cm = cf.cm
                 WHERE cf.statuscode = '".COMPILATIO_STATUSCODE_ACCEPTED."'
                 AND cc1.name = 'use_compilatio' AND cc1.value='1'


### PR DESCRIPTION
Was flooding ou mail while executing moodle cron.
  "Default exception handler: Error reading database Debug: Not unique table/alias: 'cc3'"
