### PR TITLE
Added missing code to increase attempts on file submission

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -870,6 +870,8 @@ function compilatio_send_file_to_compilatio(&$plagiarism_file, $plagiarismsettin
     }
     debugging("invalid compilatio response received - will try again later.".$id_compi);
     // Invalid response returned - increment attempt value and return false to allow this to be called again.
+    $plagiarism_file->attempt = $plagiarism_file->attempt++;
+    $DB->update_record('plagiarism_compilatio_files', $plagiarism_file);
     return false;
 }
 


### PR DESCRIPTION
Hi Dan,

I had problems with blocking files submission to Compilatio services for a long time, so I decided to dig a little bit, moodle code not being my daily cup of tea :-\

I found this missing lines of code under a comment that says "incrementing a counter", so after implementing them, the file submission queue began to fetch Compilatio services again.

I don't know the starting point of it all, but I though you might appreciate the update for reviewing.

Cheers.
Bob.
