### PR TITLE
fix typo to fix event queue blocked by a document kept in attempt=0

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -858,7 +858,7 @@ function compilatio_send_file($cmid, $userid, $file, $plagiarismsettings) {
         return false;
     }
     // Increment attempt number.
-    $plagiarism_file->attempt = $plagiarism_file->attempt++;
+    $plagiarism_file->attempt = $plagiarism_file->attempt+1;
     $DB->update_record('plagiarism_compilatio_files', $plagiarism_file);
 
     $compid = compilatio_send_file_to_compilatio($plagiarism_file, $plagiarismsettings, $file);


### PR DESCRIPTION
precision: in my case, the document error was:
Erreur SendDoc()TEXT_EXTRACTION_FAILED text extraction of file content filesize not ok!
