### PR TITLE
fix php7 warning (deprecated constructor)

### DIFF
--- a/compilatio.class.php
+++ b/compilatio.class.php
@@ -16,7 +16,7 @@ class compilatioservice {
 	var $soapcli;
 	/*Constructeur -> on cr�er la connexion avec le webservice*/
 	//MODIF 2009-03-19: passage des param�tres
-	function compilatioservice($key,$urlsoap,$proxy_host='',$proxy_port='', $proxy_username='', $proxy_password='') {
+	function __construct($key,$urlsoap,$proxy_host='',$proxy_port='', $proxy_username='', $proxy_password='') {
 		try {
 			if (!empty($key)) {
 				$this->key = $key;


### PR DESCRIPTION
Hello,

We moved our servers to PHP7, and we have this warning on each courses page: 

> Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; compilatioservice has a deprecated constructor

Can you check that our pull request fix this issue ?

Regards,