### PR TITLE
Bug 25268 problem retreive score old recipe

### DIFF
--- a/classes/compilatio/analysis.php
+++ b/classes/compilatio/analysis.php
@@ -85,7 +85,7 @@ class analysis {
             $cmpfile->status = 'error_not_found';
         }
 
-        $recipe = key($doc->analyses);
+        $recipe = array_key_first((array)$doc->analyses);
 
         if (isset($doc->analyses->$recipe->state)) {
             $state = $doc->analyses->$recipe->state;

--- a/classes/compilatio/analysis.php
+++ b/classes/compilatio/analysis.php
@@ -85,7 +85,7 @@ class analysis {
             $cmpfile->status = 'error_not_found';
         }
 
-        $recipe = get_config('plagiarism_compilatio', 'recipe');
+        $recipe = key($doc->analyses);
 
         if (isset($doc->analyses->$recipe->state)) {
             $state = $doc->analyses->$recipe->state;


### PR DESCRIPTION
Following a group's change of service, for example from Magister to Magister+, the analysis score is not updated in the Moodle DB when the analysis was performed with a recipe different from the recipe present in the Moodle configuration.