### PR TITLE
Issue#142: Fix empty assuming value zero in config as false

### DIFF
--- a/classes/compilatio/api.php
+++ b/classes/compilatio/api.php
@@ -72,7 +72,7 @@ class api {
         $this->urlrest = 'https://app.compilatio.net';
         $this->userid = $userid;
 
-        if (!empty($apikey)) {
+        if (isset($apikey) && $apikey !== '') {
             $this->apikey = $apikey;
         } else {
             return 'API key not available';


### PR DESCRIPTION
Issue: If the value on the site admin settings for apikey=>0. It goes to line 78.

With this adjustment, The value of apikey=>0 will now be read properly. Now it goes through line 76.