### PR TITLE
Correction du problème des paramètres par défaut

### DIFF
--- a/admin_tab_default_settings.php
+++ b/admin_tab_default_settings.php
@@ -22,7 +22,7 @@
  * @copyright 2025 Compilatio.net {@link https://www.compilatio.net}
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-use plagiarism_compilatio\compilatio\compilatio_defaults_form;
+use plagiarism_compilatio\compilatio\form\compilatio_defaults_form;
 
 require_once(dirname(dirname(__FILE__)) . '/../config.php');
 require_once($CFG->libdir . '/adminlib.php');

--- a/classes/compilatio/form/compilatio_defaults_form.php
+++ b/classes/compilatio/form/compilatio_defaults_form.php
@@ -26,6 +26,8 @@
 namespace plagiarism_compilatio\compilatio\form;
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.
 
+use plagiarism_compilatio\compilatio\course_module_settings;
+
 require_once($CFG->dirroot . '/lib/formslib.php');
 
 /**


### PR DESCRIPTION
Ici on corrige le problème d'instanciation de l'onglet Valeurs par défaut Compilatio de la fenêtre des paramètres du plugin.